### PR TITLE
#159791708 add username to token from social authentication

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -45,6 +45,7 @@ authRouter.get('/google/callback', (req, res, next) => {
       const token = JwtHelper.createToken({
         user: {
           id: user.id,
+          username: user.username,
           email: user.email
         }
       }, '24h');
@@ -91,6 +92,7 @@ authRouter.get('/facebook/callback', (req, res, next) => {
       const token = JwtHelper.createToken({
         user: {
           id: user.id,
+          username: user.username,
           email: user.email
         }
       }, '24h');


### PR DESCRIPTION
#### What does this PR do?
Add username to token gotten from social login authentication

#### Description of Task to be completed?
- Token gotten from google auth should return the id, username, and email
- Token gotten from facebook auth should return the id, username, and email

#### How should this be manually tested?
- on google chrome, navigate to https://authors-haven-staging.herokuapp.com/api/auth/google
- Copy the token and navigate to jwt.io
- Paste the token in the console to decode it. 

#### What are the relevant pivotal tracker stories?
[#159791708](https://www.pivotaltracker.com/story/show/159791708)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/33626790/44145116-39bdd062-a082-11e8-8051-e0018a039bf9.png)

![image](https://user-images.githubusercontent.com/33626790/44145265-ce96d54e-a082-11e8-89a9-ff662b0b015d.png)
