### PR TITLE
#159896585 Fix deserialize error on social login

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,9 @@ app.use(bodyParser.json());
 app.use(methodOverride());
 app.use(express.static(`${__dirname}/public`));
 
+app.use(passport.initialize());
+app.use(passport.session());
+
 app.use(
   session({
     secret: process.env.SESSION_KEY,
@@ -32,9 +35,6 @@ app.use(
     saveUninitialized: false,
   }),
 );
-
-app.use(passport.initialize());
-app.use(passport.session());
 
 app.use('/api', router);
 


### PR DESCRIPTION
#### What does this PR do?
Fix deserialize user error when a user logs in with social login in quick succession.

#### Description of Task to be completed?
- Passport and session should be initialized before the session is used in server/index.js
#### How should this be manually tested?
- Login at https://authors-haven-staging.herokuapp.com/api/auth/google or https://authors-haven-staging.herokuapp.com/api/auth/facebook
- Try to log in immediately after
- Returns server error. 
- Should not return error

#### What are the relevant pivotal tracker stories?
[#159896585](https://www.pivotaltracker.com/story/show/159896585)