### PR TITLE
#160216041 fix app crash on comment reply creation with invalid parentId

### DIFF
--- a/server/controllers/CommentController.js
+++ b/server/controllers/CommentController.js
@@ -19,7 +19,7 @@ export default class CommentController {
   static async createComment(req, res) {
     const { id: userId, username } = req.user;
     const { body } = req.body;
-    const parentId = req.query.id === undefined ? null : req.query.id;
+    let parentId = req.query.id === undefined ? null : req.query.id;
     const { slug } = req.params;
     const article = await CommentController.getArticleFromSlug(slug);
     if (article === null) {
@@ -28,6 +28,8 @@ export default class CommentController {
         message: 'Unable to create comment because the article does not exist.',
       });
     }
+    const parentComment = await Comment.findById(parentId);
+    if (JSON.parse(JSON.stringify(parentComment)) === null) parentId = null;
     const newComment = await Comment.create({
       articleId: article.id,
       userId,

--- a/server/middlewares/validateSlug.js
+++ b/server/middlewares/validateSlug.js
@@ -1,0 +1,16 @@
+import CommentController from '../controllers/CommentController';
+
+const validateSlug = async (req, res, next) => {
+  const { slug } = req.params;
+  const article = await CommentController.getArticleFromSlug(slug);
+  if (article === null) {
+    return res.status(400).json({
+      status: 'fail',
+      message: 'The article slug supplied is invalid.',
+    });
+  }
+  res.locals.article = article;
+  return next();
+};
+
+export default validateSlug;

--- a/server/routes/article.js
+++ b/server/routes/article.js
@@ -6,6 +6,7 @@ import CommentValidation from '../middlewares/validations/CommentValidation';
 import CommentController from '../controllers/CommentController';
 import RatingController from '../controllers/RatingController';
 import plagiarismCheck from '../middlewares/plagiarismCheck';
+import validateSlug from '../middlewares/validateSlug';
 
 const articleRouter = Router();
 
@@ -15,15 +16,15 @@ articleRouter.put('/:slug', isLoggedIn, ArticleValidation.validateUpdateArticle,
 
 articleRouter.delete('/:slug', isLoggedIn, ArticleController.removeArticle);
 
-articleRouter.post('/:slug/comments', isLoggedIn, CommentValidation.validateComment, CommentController.createComment);
+articleRouter.post('/:slug/comments', isLoggedIn, validateSlug, CommentValidation.validateComment, CommentController.createComment);
 
-articleRouter.get('/:slug/comments', isLoggedIn, CommentController.getComments);
+articleRouter.get('/:slug/comments', isLoggedIn, validateSlug, CommentController.getComments);
 
-articleRouter.get('/:slug/comments/:id', isLoggedIn, CommentController.getComment);
+articleRouter.get('/:slug/comments/:id', isLoggedIn, validateSlug, CommentController.getComment);
 
-articleRouter.put('/:slug/comments/:id', isLoggedIn, CommentValidation.validateComment, CommentController.updateComment);
+articleRouter.put('/:slug/comments/:id', isLoggedIn, validateSlug, CommentValidation.validateComment, CommentController.updateComment);
 
-articleRouter.delete('/:slug/comments/:id', isLoggedIn, CommentController.deleteComment);
+articleRouter.delete('/:slug/comments/:id', isLoggedIn, validateSlug, CommentController.deleteComment);
 
 articleRouter.post('/:author/:slug/:rating', isLoggedIn, RatingController.prepRating);
 

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -88,6 +88,9 @@ describe('Comment Tests', () => {
     it('should ask the user to log in', (done) => {
       chai.request(app)
         .post(`/api/articles/${validSlug}/comments`)
+        .send({
+          body: 'I am a valid comment.',
+        })
         .end((req, res) => {
           res.status.should.eql(401);
           res.body.should.be.an('object').with.property('errors');
@@ -117,9 +120,6 @@ describe('Comment Tests', () => {
         .post(`/api/articles/${validSlug}/comments`)
         .set('x-access-token', token)
         .send({
-          articleId: validId,
-          userId: user.id,
-          parentId: null,
           body: 'I am a valid comment.',
         })
         .end((req, res) => {
@@ -136,9 +136,6 @@ describe('Comment Tests', () => {
         .post('/api/articles/invalid-slug-87123/comments')
         .set('x-access-token', token)
         .send({
-          articleId: validId,
-          userId: user.id,
-          parentId: null,
           body: 'I am a valid comment.',
         })
         .end((req, res) => {
@@ -150,15 +147,30 @@ describe('Comment Tests', () => {
     });
   });
 
+  describe('Comment reply creation with invalid parent id', () => {
+    it('should create the comment as a first level comment', (done) => {
+      chai.request(app)
+        .post(`/api/articles/${validSlug}/comments?id=-1`)
+        .set('x-access-token', token)
+        .send({
+          body: 'I am a valid comment.',
+        })
+        .end((req, res) => {
+          res.status.should.eql(201);
+          res.body.should.be.an('object').with.property('status').eql('success');
+          res.body.comment.should.have.property('article').include(validSlug);
+          res.body.comment.should.have.property('parentId').eql(null);
+          done();
+        });
+    });
+  });
+
   describe('Comment creation with valid token but no body', () => {
     it('should throw an error', (done) => {
       chai.request(app)
         .post(`/api/articles/${validSlug}/comments`)
         .set('x-access-token', token)
         .send({
-          articleSlug: validSlug,
-          author: user.id,
-          parentId: null,
         })
         .end((req, res) => {
           res.status.should.eql(400);

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -267,7 +267,7 @@ describe('Comment Tests', () => {
         });
     });
 
-    it('should throw an error when invalid comment id is supplied', (done) => {
+    it('should throw an error when supplied comment id is not a number', (done) => {
       chai.request(app)
         .delete(`/api/articles/${validSlug}/comments/rer`)
         .set('x-access-token', token)
@@ -275,6 +275,31 @@ describe('Comment Tests', () => {
           res.status.should.eql(400);
           res.body.should.be.an('object').with.property('status').include('fail');
           res.body.should.have.property('message').include('Please supply a valid comment id.');
+          done();
+        });
+    });
+
+    it('should throw an error when supplied comment id is a number, but does not exist in the db', (done) => {
+      chai.request(app)
+        .get(`/api/articles/${validSlug}/comments/900`)
+        .set('x-access-token', token)
+        .end((req, res) => {
+          res.status.should.eql(404);
+          res.body.should.be.an('object').with.property('status').include('fail');
+          res.body.should.have.property('message').include('Unable to get the comment with supplied id.');
+          done();
+        });
+    });
+
+    it('should throw an error when supplied comment id is a number, but does not exist in the db', (done) => {
+      chai.request(app)
+        .put(`/api/articles/${validSlug}/comments/900`)
+        .set('x-access-token', token)
+        .send({ body: 'UPDATED COMMENT' })
+        .end((req, res) => {
+          res.status.should.eql(404);
+          res.body.should.be.an('object').with.property('status').include('fail');
+          res.body.should.have.property('message').include('No comment found, please check the id supplied.');
           done();
         });
     });

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -141,7 +141,7 @@ describe('Comment Tests', () => {
         .end((req, res) => {
           res.status.should.eql(400);
           res.body.should.be.an('object').with.property('status').eql('fail');
-          res.body.should.have.property('message').include('Unable to create comment because the article does not exist.');
+          res.body.should.have.property('message').include('The article slug supplied is invalid.');
           done();
         });
     });
@@ -274,7 +274,7 @@ describe('Comment Tests', () => {
         .end((req, res) => {
           res.status.should.eql(400);
           res.body.should.be.an('object').with.property('status').include('fail');
-          res.body.should.have.property('message').include('Invalid comment id supplied.');
+          res.body.should.have.property('message').include('Please supply a valid comment id.');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
Fixes app crash when a user tries to reply to a comment with an invalid parentId by setting the new comment as a first level comment instead

#### Description of Task to be completed?
- Fix app crash when invalid comment id is supplied on comment creation by throwing an error
- Create comment reply as a first level comment when invalid parentId is supplied

#### How should this be manually tested?
- Clone the repo: Run `git clone https://github.com/andela/elven-ah.git` in the folder where you want the repo to be saved.
- Navigate into the newly created folder and install the dependencies: `cd elven-ah && npm install`
- Copy .env.example to .env: `cp .env.example .env`
- Provision a PostgreSQL database and add the credentials to the .env file. 
- Start the server using `npm start`
- create an account and create an article or seed some articles
- Open http://localhost:3000 in a browser and log in with any of the seeded users
- Then using postman create a comment to an article and add an invalid `id` query param
- This will create the comment as a first level comment. Previously the app just crashed.

#### What are the relevant pivotal tracker stories? 
[#160216041](https://www.pivotaltracker.com/story/show/160216041)