### PR TITLE
#160507489 fix failing build on Heroku

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "express-authorshaven",
   "version": "1.0.0",
+  "engines": {
+    "node": "8.9.4",
+    "npm": "5.6.0"
+  },
   "description": "A Social platform for the creative at heart",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do?
- fix failing build on Heroku due to NodeJS update

#### Description of Task to be completed?
- add .npmrc file with config
- specify node and npm version in package.json

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
- The new Node version (Node 8.12.0) installed by default on Heroku does not come with a build for _bcrypt_, so building the app on Heroku fails. I had to manually specify an earlier node version that worked with bcrypt in other for the build to succeed.

#### What are the relevant pivotal tracker stories?
- [#160507489](https://www.pivotaltracker.com/story/show/160507489)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A

[Delivers #160507489]