### PR TITLE
#160690389 remove username from required signup details and make it updateable

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "server/index.js",
   "scripts": {
     "test": "npm run test:v1",
-    "test:v1": "npm run migrate:test && cross-env NODE_ENV=test nyc --reporter=html --reporter=text mocha --timeout 30000 --exit --require babel-register ./server/v1/tests/**/*.test.js",
+    "test:v1": "npm run migrate:test && cross-env NODE_ENV=test nyc --reporter=html --reporter=text mocha --timeout 90000 --exit --require babel-register ./server/v1/tests/**/*.test.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test",
     "prestart": "sequelize db:migrate",

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -3,12 +3,12 @@ const strategies = {
   google: {
     clientID: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackURL: process.env.GOOGLE_CALLBACK_URL || 'http://elven-ah-client.herokuapp.com/oauth2/google',
+    callbackURL: process.env.GOOGLE_CALLBACK_URL || 'https://elven-ah-develop.herokuapp.com/oauth2/google',
   },
   facebook: {
     clientID: process.env.FACEBOOK_CLIENT_ID,
     clientSecret: process.env.FACEBOOK_CLIENT_SECRET,
-    callbackURL: process.env.FACEBOOK_CALLBACK_URL || 'http://elven-ah-client.herokuapp.com/oauth2/facebook',
+    callbackURL: process.env.FACEBOOK_CALLBACK_URL || 'https://elven-ah-develop.herokuapp.com/oauth2/facebook',
   },
   twitter: {
     consumerKey: 'get_your_own',

--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ app.use((err, req, res, next) => {
   res.send({
     status: 'error',
     message: err.message,
-    error: env === 'production' ? {} : err,
+    error: env === 'production' ? {} : next(err),
   });
 });
 // finally, let's start our server...

--- a/server/index.js
+++ b/server/index.js
@@ -51,9 +51,9 @@ app.all('*', (req, res) => {
 
 // Error handler
 // no stack traces leaked to user in production
-app.use((err, req, res) => {
+app.use((err, req, res, next) => {
   res.status(err.status || 500);
-  res.json({
+  res.send({
     status: 'error',
     message: err.message,
     error: env === 'production' ? {} : err,

--- a/server/seeders/20180808181558-demo-Article.js
+++ b/server/seeders/20180808181558-demo-Article.js
@@ -107,14 +107,14 @@ module.exports = {
     {
       title: 'arts is wonderful',
       body: 'lkjslkdjfkdjflk',
-      slug: 'arts-is-wonderful-120794ujhd',
+      slug: 'arts-is-wonderful-120794ujab',
       userId: 1,
       categoryId: 5,
       createdAt: '2018-07-08 18:31:22.324',
       updatedAt: '2018-08-09 18:31:22.324'
     },
     {
-      slug: 'the-first-article-by-the-user',
+      slug: 'the-first-article-by-the-usercd',
       userId: 1,
       categoryId: 2,
       title: 'The first article by the user',
@@ -123,7 +123,7 @@ module.exports = {
       updatedAt: '2018-08-04 21:54:49'
     },
     {
-      slug: 'the-second-article-by-the-user',
+      slug: 'the-second-article-by-the-useref',
       userId: 1,
       categoryId: 2,
       title: 'The second article by the user',
@@ -132,7 +132,7 @@ module.exports = {
       updatedAt: '2018-08-04 21:54:49'
     },
     {
-      slug: 'the-first-article-by-another-user',
+      slug: 'the-first-article-by-another-usergh',
       userId: 2,
       categoryId: 3,
       title: 'The first article by another user',
@@ -141,7 +141,7 @@ module.exports = {
       updatedAt: '2018-08-04 21:54:49'
     },
     {
-      slug: 'the-second-article-by-another-user',
+      slug: 'the-second-article-by-another-userij',
       userId: 2,
       categoryId: 2,
       title: 'The second article by another user',
@@ -150,7 +150,7 @@ module.exports = {
       updatedAt: '2018-08-04 21:54:49'
     },
     {
-      slug: 'other-articles-by-other-users',
+      slug: 'other-articles-by-other-userskl',
       userId: 3,
       categoryId: 2,
       title: 'Other articles by other users',
@@ -159,7 +159,7 @@ module.exports = {
       updatedAt: '2018-08-04 21:54:49'
     },
     {
-      slug: 'the-second-article-by-other-user',
+      slug: 'the-second-article-by-other-usermn',
       userId: 3,
       categoryId: 2,
       title: 'The second article by other user',
@@ -169,7 +169,7 @@ module.exports = {
     },
     {
       title: 'Unmissable steps before, during, and after user research',
-      slug: 'unmissable-steps-before-74U33U38N3IHF1',
+      slug: 'unmissable-steps-before-74U33U38N3IHop',
       userId: 1,
       categoryId: 2,
       body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537883927710-61d5d1a2c1e9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0bf498a63b771656f26a8124eeb3e6be&auto=format&fit=crop&w=1868&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
@@ -179,7 +179,7 @@ module.exports = {
     },
     {
       title: 'Unmissable steps before, during, and after user research',
-      slug: 'unmissable-steps-before-74U33U38N3IHF2',
+      slug: 'unmissable-steps-before-74U33U38N3IHqr',
       userId: 1,
       categoryId: 1,
       body: ' <img src="https://images.unsplash.com/photo-1537964769190-561c0c37b043?ixlib=rb-0.3.5&s=5c6fad276a1cbb344dd7efb6d0688845&auto=format&fit=crop&w=934&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
@@ -189,7 +189,7 @@ module.exports = {
     },
     {
       title: 'Unmissable steps before, during, and after user research',
-      slug: 'unmissable-steps-before-74U33U38N3IHF3',
+      slug: 'unmissable-steps-before-74U33U38N3IHst',
       userId: 1,
       categoryId: 1,
       body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537954406021-d821481dc0d9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0eb0e27031c32c088953a961c4e5d816&auto=format&fit=crop&w=1000&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
@@ -199,7 +199,7 @@ module.exports = {
     },
     {
       title: 'Unmissable steps before, during, and after user research',
-      slug: 'unmissable-steps-before-74U33U38N3IHF4',
+      slug: 'unmissable-steps-before-74U33U38N3IHuv',
       userId: 1,
       categoryId: 1,
       body: '<img src="https://images.unsplash.com/photo-1537891115166-4affb371bbd1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=12e8833208e9f57f3421fad30f9af988&auto=format&fit=crop&w=2100&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',

--- a/server/seeders/20180808181558-demo-Article.js
+++ b/server/seeders/20180808181558-demo-Article.js
@@ -15,7 +15,7 @@ module.exports = {
       userId: 1,
       categoryId: 2,
       title: 'The first article by the user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database <img src="https://images.unsplash.com/photo-1537970264887-190be0b36591?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0f991d8c968e4aafeee7e8e4a44193c5&auto=format&fit=crop&w=2100&q=80" /> with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -24,7 +24,7 @@ module.exports = {
       userId: 1,
       categoryId: 2,
       title: 'The second article by the user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns <img src="https://images.unsplash.com/photo-1537941032657-672864703060?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4e25dea0cf8dd7808c7bfbdecc6a02a1&auto=format&fit=crop&w=934&q=80" /> the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -33,7 +33,7 @@ module.exports = {
       userId: 2,
       categoryId: 3,
       title: 'The first article by another user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537927863396-55452cdd2096?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0514d6e6eff1a74a5439515bb958ecbd&auto=format&fit=crop&w=975&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -42,7 +42,7 @@ module.exports = {
       userId: 2,
       categoryId: 2,
       title: 'The second article by another user',
-      body: 'One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
+      body: '<img src="https://images.unsplash.com/photo-1537914374312-88a58ed95a82?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=e237b83a0dd3e5746e068938f6e49861&auto=format&fit=crop&w=2100&q=80" /> One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -51,7 +51,7 @@ module.exports = {
       userId: 3,
       categoryId: 2,
       title: 'Other articles by other users',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: ' <img src="https://images.unsplash.com/photo-1537953773345-d172ccf13cf1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4d805214562c44ffd6de6cb7954405ab&auto=format&fit=crop&w=975&q=80" />This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -60,7 +60,7 @@ module.exports = {
       userId: 3,
       categoryId: 2,
       title: 'The second article by other user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537946601344-843035066851?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4f977d92f87634b9b9fc1aa0f35dd050&auto=format&fit=crop&w=934&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -69,7 +69,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF1',
       userId: 1,
       categoryId: 2,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537883927710-61d5d1a2c1e9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0bf498a63b771656f26a8124eeb3e6be&auto=format&fit=crop&w=1868&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -79,7 +79,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF2',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: ' <img src="https://images.unsplash.com/photo-1537964769190-561c0c37b043?ixlib=rb-0.3.5&s=5c6fad276a1cbb344dd7efb6d0688845&auto=format&fit=crop&w=934&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -89,7 +89,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF3',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537954406021-d821481dc0d9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0eb0e27031c32c088953a961c4e5d816&auto=format&fit=crop&w=1000&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -99,7 +99,110 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF4',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: '<img src="https://images.unsplash.com/photo-1537891115166-4affb371bbd1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=12e8833208e9f57f3421fad30f9af988&auto=format&fit=crop&w=2100&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'arts is wonderful',
+      body: 'lkjslkdjfkdjflk',
+      slug: 'arts-is-wonderful-120794ujhd',
+      userId: 1,
+      categoryId: 5,
+      createdAt: '2018-07-08 18:31:22.324',
+      updatedAt: '2018-08-09 18:31:22.324'
+    },
+    {
+      slug: 'the-first-article-by-the-user',
+      userId: 1,
+      categoryId: 2,
+      title: 'The first article by the user',
+      body: 'This is great because it updates the database <img src="https://images.unsplash.com/photo-1537970264887-190be0b36591?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0f991d8c968e4aafeee7e8e4a44193c5&auto=format&fit=crop&w=2100&q=80" /> with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-the-user',
+      userId: 1,
+      categoryId: 2,
+      title: 'The second article by the user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns <img src="https://images.unsplash.com/photo-1537941032657-672864703060?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4e25dea0cf8dd7808c7bfbdecc6a02a1&auto=format&fit=crop&w=934&q=80" /> the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-first-article-by-another-user',
+      userId: 2,
+      categoryId: 3,
+      title: 'The first article by another user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537927863396-55452cdd2096?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0514d6e6eff1a74a5439515bb958ecbd&auto=format&fit=crop&w=975&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-another-user',
+      userId: 2,
+      categoryId: 2,
+      title: 'The second article by another user',
+      body: '<img src="https://images.unsplash.com/photo-1537914374312-88a58ed95a82?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=e237b83a0dd3e5746e068938f6e49861&auto=format&fit=crop&w=2100&q=80" /> One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'other-articles-by-other-users',
+      userId: 3,
+      categoryId: 2,
+      title: 'Other articles by other users',
+      body: ' <img src="https://images.unsplash.com/photo-1537953773345-d172ccf13cf1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4d805214562c44ffd6de6cb7954405ab&auto=format&fit=crop&w=975&q=80" />This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-other-user',
+      userId: 3,
+      categoryId: 2,
+      title: 'The second article by other user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537946601344-843035066851?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4f977d92f87634b9b9fc1aa0f35dd050&auto=format&fit=crop&w=934&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHF1',
+      userId: 1,
+      categoryId: 2,
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537883927710-61d5d1a2c1e9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0bf498a63b771656f26a8124eeb3e6be&auto=format&fit=crop&w=1868&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHF2',
+      userId: 1,
+      categoryId: 1,
+      body: ' <img src="https://images.unsplash.com/photo-1537964769190-561c0c37b043?ixlib=rb-0.3.5&s=5c6fad276a1cbb344dd7efb6d0688845&auto=format&fit=crop&w=934&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHF3',
+      userId: 1,
+      categoryId: 1,
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537954406021-d821481dc0d9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0eb0e27031c32c088953a961c4e5d816&auto=format&fit=crop&w=1000&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHF4',
+      userId: 1,
+      categoryId: 1,
+      body: '<img src="https://images.unsplash.com/photo-1537891115166-4affb371bbd1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=12e8833208e9f57f3421fad30f9af988&auto=format&fit=crop&w=2100&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'

--- a/server/seeders/20180808181558-demo-Article.js
+++ b/server/seeders/20180808181558-demo-Article.js
@@ -15,7 +15,7 @@ module.exports = {
       userId: 1,
       categoryId: 2,
       title: 'The first article by the user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database <img src="https://images.unsplash.com/photo-1537970264887-190be0b36591?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0f991d8c968e4aafeee7e8e4a44193c5&auto=format&fit=crop&w=2100&q=80" /> with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -24,7 +24,7 @@ module.exports = {
       userId: 1,
       categoryId: 2,
       title: 'The second article by the user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns <img src="https://images.unsplash.com/photo-1537941032657-672864703060?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4e25dea0cf8dd7808c7bfbdecc6a02a1&auto=format&fit=crop&w=934&q=80" /> the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -33,7 +33,7 @@ module.exports = {
       userId: 2,
       categoryId: 3,
       title: 'The first article by another user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537927863396-55452cdd2096?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0514d6e6eff1a74a5439515bb958ecbd&auto=format&fit=crop&w=975&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -42,7 +42,7 @@ module.exports = {
       userId: 2,
       categoryId: 2,
       title: 'The second article by another user',
-      body: 'One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
+      body: '<img src="https://images.unsplash.com/photo-1537914374312-88a58ed95a82?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=e237b83a0dd3e5746e068938f6e49861&auto=format&fit=crop&w=2100&q=80" /> One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -51,7 +51,7 @@ module.exports = {
       userId: 3,
       categoryId: 2,
       title: 'Other articles by other users',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: ' <img src="https://images.unsplash.com/photo-1537953773345-d172ccf13cf1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4d805214562c44ffd6de6cb7954405ab&auto=format&fit=crop&w=975&q=80" />This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -60,7 +60,7 @@ module.exports = {
       userId: 3,
       categoryId: 2,
       title: 'The second article by other user',
-      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537946601344-843035066851?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4f977d92f87634b9b9fc1aa0f35dd050&auto=format&fit=crop&w=934&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
       createdAt: '2018-08-01 21:54:49',
       updatedAt: '2018-08-04 21:54:49'
     },
@@ -69,7 +69,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF1',
       userId: 1,
       categoryId: 2,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537883927710-61d5d1a2c1e9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0bf498a63b771656f26a8124eeb3e6be&auto=format&fit=crop&w=1868&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -79,7 +79,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF2',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: ' <img src="https://images.unsplash.com/photo-1537964769190-561c0c37b043?ixlib=rb-0.3.5&s=5c6fad276a1cbb344dd7efb6d0688845&auto=format&fit=crop&w=934&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -89,7 +89,7 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF3',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537954406021-d821481dc0d9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0eb0e27031c32c088953a961c4e5d816&auto=format&fit=crop&w=1000&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'
@@ -99,7 +99,110 @@ module.exports = {
       slug: 'unmissable-steps-before-74U33U38N3IHF4',
       userId: 1,
       categoryId: 1,
-      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      body: '<img src="https://images.unsplash.com/photo-1537891115166-4affb371bbd1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=12e8833208e9f57f3421fad30f9af988&auto=format&fit=crop&w=2100&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'arts is wonderful',
+      body: 'lkjslkdjfkdjflk',
+      slug: 'arts-is-wonderful-120794ujab',
+      userId: 1,
+      categoryId: 5,
+      createdAt: '2018-07-08 18:31:22.324',
+      updatedAt: '2018-08-09 18:31:22.324'
+    },
+    {
+      slug: 'the-first-article-by-the-usercd',
+      userId: 1,
+      categoryId: 2,
+      title: 'The first article by the user',
+      body: 'This is great because it updates the database <img src="https://images.unsplash.com/photo-1537970264887-190be0b36591?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0f991d8c968e4aafeee7e8e4a44193c5&auto=format&fit=crop&w=2100&q=80" /> with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-the-useref',
+      userId: 1,
+      categoryId: 2,
+      title: 'The second article by the user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. But it returns <img src="https://images.unsplash.com/photo-1537941032657-672864703060?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4e25dea0cf8dd7808c7bfbdecc6a02a1&auto=format&fit=crop&w=934&q=80" /> the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-first-article-by-another-usergh',
+      userId: 2,
+      categoryId: 3,
+      title: 'The first article by another user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537927863396-55452cdd2096?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0514d6e6eff1a74a5439515bb958ecbd&auto=format&fit=crop&w=975&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-another-userij',
+      userId: 2,
+      categoryId: 2,
+      title: 'The second article by another user',
+      body: '<img src="https://images.unsplash.com/photo-1537914374312-88a58ed95a82?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=e237b83a0dd3e5746e068938f6e49861&auto=format&fit=crop&w=2100&q=80" /> One of the projects I was assigned to involved a drug that was targeted at women. The graphics and general style of the website made it clear that the client wanted to specifically target teenage girls. One of the features of this website was a quiz that asked girls a series of questions and recommended a type of drug based on their answers.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'other-articles-by-other-userskl',
+      userId: 3,
+      categoryId: 2,
+      title: 'Other articles by other users',
+      body: ' <img src="https://images.unsplash.com/photo-1537953773345-d172ccf13cf1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4d805214562c44ffd6de6cb7954405ab&auto=format&fit=crop&w=975&q=80" />This is great because it updates the database with the new book title for the matching book id. But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      slug: 'the-second-article-by-other-usermn',
+      userId: 3,
+      categoryId: 2,
+      title: 'The second article by other user',
+      body: 'This is great because it updates the database with the new book title for the matching book id. <img src="https://images.unsplash.com/photo-1537946601344-843035066851?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=4f977d92f87634b9b9fc1aa0f35dd050&auto=format&fit=crop&w=934&q=80" /> But it returns the number of rows updated. This is rarely useful on the front-end. More likely we would want to do something with the updated book on the front-end. Of course, we can then query the database in a .then and get that books information, but there has to be a better way! And there is.',
+      createdAt: '2018-08-01 21:54:49',
+      updatedAt: '2018-08-04 21:54:49'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHop',
+      userId: 1,
+      categoryId: 2,
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537883927710-61d5d1a2c1e9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0bf498a63b771656f26a8124eeb3e6be&auto=format&fit=crop&w=1868&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHqr',
+      userId: 1,
+      categoryId: 1,
+      body: ' <img src="https://images.unsplash.com/photo-1537964769190-561c0c37b043?ixlib=rb-0.3.5&s=5c6fad276a1cbb344dd7efb6d0688845&auto=format&fit=crop&w=934&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHst',
+      userId: 1,
+      categoryId: 1,
+      body: 'As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. <img src="https://images.unsplash.com/photo-1537954406021-d821481dc0d9?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=0eb0e27031c32c088953a961c4e5d816&auto=format&fit=crop&w=1000&q=80" /> I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
+      imageUrl: 'https://cloudinary/ah/images/miss.jpg',
+      createdAt: 'NOW()',
+      updatedAt: 'NOW()'
+    },
+    {
+      title: 'Unmissable steps before, during, and after user research',
+      slug: 'unmissable-steps-before-74U33U38N3IHuv',
+      userId: 1,
+      categoryId: 1,
+      body: '<img src="https://images.unsplash.com/photo-1537891115166-4affb371bbd1?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=12e8833208e9f57f3421fad30f9af988&auto=format&fit=crop&w=2100&q=80" /> As a UX designer, I’m expected to run research studies to mine meaningful insights for my products. I often conduct usability studies to get a pulse of what users think, need or expect from a new product. I was fortunate to work on consumer-facing as well as enterprise products, as a result of which, I gained a diverse experience relevant to conducting user studies in industrial settings. While the commercial products gave us the liberty to find and interview users in person, the enterprise products on the other hand make it difficult to find or access the right users, resulting in remote usability studies.',
       imageUrl: 'https://cloudinary/ah/images/miss.jpg',
       createdAt: 'NOW()',
       updatedAt: 'NOW()'

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -25,6 +25,11 @@ export default class AuthController {
     };
   }
 
+  /**
+   * @description creates a username from the firstName and a random set of strings
+   * @param {String} firstName The first name of the user from which the username will be generated
+   * @returns {String} Returns a username
+   */
   static createUsername(firstName) {
     return `${firstName}-${randomString(4)}`;
   }

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -35,15 +35,6 @@ export default class AuthController {
   }
 
   /**
-   * @description creates a username from the firstName and a random set of strings
-   * @param {String} firstName The first name of the user from which the username will be generated
-   * @returns {String} Returns a username
-   */
-  static createUsername(firstName) {
-    return `${firstName}-${randomString(4)}`;
-  }
-
-  /**
    * @description Formats the message sent to the user on successful login/registration
    * This will ensure that all response is formatted in the same way.
    * @param {Object} status The status of the response (include statusCode and message)

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -88,7 +88,7 @@ export default class AuthController {
     const {
       email, firstName, lastName, password,
     } = req.body;
-    const username = AuthController.createUsername(firstName, lastName);
+    const username = AuthController.createUsername(firstName);
     return User.findOrCreate({
       where: { email },
       defaults: {

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -25,6 +25,10 @@ export default class AuthController {
     };
   }
 
+  static createUsername(firstName) {
+    return `${firstName}-${randomString(4)}`;
+  }
+
   /**
    * @description creates a username from the firstName and a random set of strings
    * @param {String} firstName The first name of the user from which the username will be generated

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt';
 import models from '../../models';
 import JwtHelper from '../helpers/JwtHelper';
 import NotificationController from './NotificationController';
+import randomString from '../helpers/randomString';
 
 const { User } = models;
 
@@ -22,6 +23,10 @@ export default class AuthController {
     return {
       id, email, username, firstName, lastName, bio, image
     };
+  }
+
+  static createUsername(firstName) {
+    return `${firstName}-${randomString(4)}`;
   }
 
   /**
@@ -76,16 +81,11 @@ export default class AuthController {
    */
   static signUpUser(req, res, next) {
     const {
-      email, username, firstName, lastName, password,
+      email, firstName, lastName, password,
     } = req.body;
+    const username = AuthController.createUsername(firstName, lastName);
     return User.findOrCreate({
-      where: {
-        $or: [{
-          email
-        }, {
-          username
-        }]
-      },
+      where: { email },
       defaults: {
         email,
         username,

--- a/server/v1/controllers/ProfileController.js
+++ b/server/v1/controllers/ProfileController.js
@@ -16,7 +16,7 @@ export default class ProfileController {
   * @param {object} res the response object
   * @returns {user} the user object
   */
-  static getUserProfile(req, res, next) {
+  static getUserProfile(req, res) {
     const { username: loggedInUser } = req.user;
     const { username } = req.params;
     return User.findOne(Object.assign({}, queryHelper.userProfile, { where: { username } }))
@@ -28,7 +28,10 @@ export default class ProfileController {
             user,
           });
         }
-        return next();
+        res.status(404).json({
+          status: 'error',
+          message: 'User with the supplied username does not exist.'
+        });
       });
   }
 
@@ -40,14 +43,14 @@ export default class ProfileController {
   */
   static updateUserProfile(req, res) {
     const {
-      email, firstName, lastName, bio, image
+      email, firstName, lastName, bio, image, username
     } = req.body;
     const { username: loggedInUser } = req.user;
-    const { username } = req.params;
-    if (loggedInUser === username) {
+    const { username: userToUpdate } = req.params;
+    if (loggedInUser === userToUpdate) {
       return User.update({
-        email, firstName, lastName, bio, image
-      }, { returning: true, where: { username } })
+        email, firstName, lastName, bio, image, username,
+      }, { returning: true, where: { username: loggedInUser } })
         .then(([, [user]]) => res.status(200).json({
           status: 'success',
           user: AuthController.stripeUser(user),

--- a/server/v1/controllers/ProfileController.js
+++ b/server/v1/controllers/ProfileController.js
@@ -41,12 +41,18 @@ export default class ProfileController {
   * @param {object} res the response object
   * @returns the updated user profile
   */
-  static updateUserProfile(req, res) {
+  static async updateUserProfile(req, res) {
     const {
       email, firstName, lastName, bio, image, username
     } = req.body;
     const { username: loggedInUser } = req.user;
     const { username: userToUpdate } = req.params;
+    if (await ProfileController.usernameExists(username) !== null && username !== loggedInUser) {
+      return res.status(409).json({
+        status: 'error',
+        message: 'The username already exists',
+      });
+    }
     if (loggedInUser === userToUpdate) {
       return User.update({
         email, firstName, lastName, bio, image, username,
@@ -60,6 +66,15 @@ export default class ProfileController {
       status: 'error',
       message: 'You can only edit your own profile',
     });
+  }
+
+  /**
+   * @description checks if new username exists in the db
+   * @param {string} username the new username
+   */
+  static async usernameExists(username) {
+    const existingUser = await User.findOne({ where: { username: `${username}` } });
+    return existingUser;
   }
 
   /**

--- a/server/v1/controllers/SearchController.js
+++ b/server/v1/controllers/SearchController.js
@@ -17,6 +17,7 @@ class SearchController {
     const keyword = req.query.q;
     const userSearch = await User.findAll({
       where: { $or: { username: { $ilike: `%${keyword}%` }, firstName: { $ilike: `%${keyword}%` }, lastName: { $ilike: `%${keyword}%` }, }, },
+      attributes: { exclude: ['password'] },
       order: [
         ['username', 'DESC']
       ],

--- a/server/v1/middlewares/validations/UserValidation.js
+++ b/server/v1/middlewares/validations/UserValidation.js
@@ -91,6 +91,7 @@ class UserValidation {
     const userUpdateProperties = {
       firstName: 'alpha|min:2|max:100',
       lastName: 'alpha|min:2|max:100',
+      username: 'required|alpha_num|min:5|max:105',
       email: 'required|email',
       bio: 'min:20|max:4000',
       image: 'url'

--- a/server/v1/middlewares/validations/UserValidation.js
+++ b/server/v1/middlewares/validations/UserValidation.js
@@ -13,7 +13,6 @@ class UserValidation {
       firstName: 'required|alpha|min:2|max:100',
       lastName: 'required|alpha|min:2|max:100',
       email: 'required|email',
-      username: 'required|alpha_num|min:5|max:15',
       password: 'required|alpha_num|min:8|max:20',
       confirmPassword: 'required|alpha_num|min:8|max:20|same:password',
     };

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -184,4 +184,18 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         done();
       });
   });
+  it('should return 409 when a user wants to update to a username that belongs to another user', (done) => {
+    chai.request(app).put('/api/v1/users/JohnAwesome')
+      .set('x-access-token', userToken)
+      .send({
+        email: 'johndoe@mail.com',
+        username: 'oyomi'
+      })
+      .end((req, res) => {
+        res.status.should.eql(409);
+        res.body.should.be.a('object');
+        res.body.should.have.property('status').eql('error');
+        done();
+      });
+  });
 });

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -184,4 +184,18 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         done();
       });
   });
+  it('should return 409 when a user wants to update to a username that belongs to another user', (done) => {
+    chai.request(app).put('/api/v1/users/JohnAwesome')
+      .set('x-access-token', userToken)
+      .send({
+        email: 'janeBlaise@gmail.com',
+        username: 'JohnAwesome'
+      })
+      .end((req, res) => {
+        res.status.should.eql(409);
+        res.body.should.be.a('object');
+        res.body.should.have.property('status').eql('error');
+        done();
+      });
+  });
 });

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -57,6 +57,17 @@ describe('GET /api/v1/users/:username Tests for user view profile endpoint', () 
         done();
       });
   });
+
+  it('should return 404 when a non-existent username is supplied', (done) => {
+    chai.request(app).get('/api/v1/users/jjahhshg')
+      .set('x-access-token', userToken)
+      .end((req, res) => {
+        res.status.should.eql(404);
+        res.body.should.be.an('object');
+        res.body.should.have.property('message').include('User with the supplied username does not exist.');
+        done();
+      });
+  });
 });
 
 describe('PUT /api/v1/users/:username Tests for user update profile endpoint', () => {
@@ -80,6 +91,7 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         firstName: 'John',
         lastName: 'Doe',
         email: 'johndoe@mail.com',
+        username: 'JohnAwesome',
         bio: `John Doe was born in 1977 when he arrived in Los Angeles. 
         His previous life in Tennessee, 
         Wisconsin & Baltimore was a great & fertile time but 
@@ -109,6 +121,7 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         firstName: 'John',
         lastName: 'Doe',
         email: 'johndoe@mail.com',
+        username: 'JohnAwesome',
         bio: `John Doe was born in 1977 when he arrived in Los Angeles. 
         His previous life in Tennessee, 
         Wisconsin & Baltimore was a great & fertile time but 
@@ -124,7 +137,7 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
       });
   });
 
-  it('should return 400 when a user does not provide an email', (done) => {
+  it('should return 400 when a user does not provide an email or username', (done) => {
     chai.request(app).put('/api/v1/users/JohnAwesome')
       .set('x-access-token', userToken)
       .end((req, res) => {
@@ -134,6 +147,7 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         res.body.should.have.property('errors');
         res.body.errors.should.be.a('object');
         res.body.errors.should.have.property('email').include('The email field is required.');
+        res.body.errors.should.have.property('username').include('The username field is required.');
         done();
       });
   });
@@ -161,6 +175,7 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
       .set('x-access-token', userToken)
       .send({
         email: 'janeBlaise@gmail.com',
+        username: 'JohnAwesome'
       })
       .end((req, res) => {
         res.status.should.eql(409);

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -184,18 +184,4 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
         done();
       });
   });
-  it('should return 409 when a user wants to update to a username that belongs to another user', (done) => {
-    chai.request(app).put('/api/v1/users/JohnAwesome')
-      .set('x-access-token', userToken)
-      .send({
-        email: 'johndoe@mail.com',
-        username: 'oyomi'
-      })
-      .end((req, res) => {
-        res.status.should.eql(409);
-        res.body.should.be.a('object');
-        res.body.should.have.property('status').eql('error');
-        done();
-      });
-  });
 });

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -174,8 +174,8 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
     chai.request(app).put('/api/v1/users/JohnAwesome')
       .set('x-access-token', userToken)
       .send({
-        email: 'janeBlaise@gmail.com',
-        username: 'JohnAwesome'
+        email: 'johndoe@mail.com',
+        username: 'oyomi'
       })
       .end((req, res) => {
         res.status.should.eql(409);

--- a/server/v1/tests/userProfile.test.js
+++ b/server/v1/tests/userProfile.test.js
@@ -188,8 +188,8 @@ describe('PUT /api/v1/users/:username Tests for user update profile endpoint', (
     chai.request(app).put('/api/v1/users/JohnAwesome')
       .set('x-access-token', userToken)
       .send({
-        email: 'janeBlaise@gmail.com',
-        username: 'JohnAwesome'
+        email: 'johndoe@mail.com',
+        username: 'oyomi'
       })
       .end((req, res) => {
         res.status.should.eql(409);

--- a/server/v1/tests/userSignup.test.js
+++ b/server/v1/tests/userSignup.test.js
@@ -11,7 +11,6 @@ chai.use(chaiHttp);
 const user = {
   firstName: 'John',
   lastName: 'Doe',
-  username: 'johnny',
   email: 'testuser@test.com',
   password: 'Qwertyui0p',
   confirmPassword: 'Qwertyui0p',
@@ -19,7 +18,6 @@ const user = {
 const userWithAlreadyUsedEmail = {
   firstName: 'John',
   lastName: 'Doe',
-  username: 'johnnyllllee',
   email: 'testuser@test.com',
   password: 'Qwertyui0p',
   confirmPassword: 'Qwertyui0p',
@@ -46,7 +44,7 @@ describe('User signup', () => {
   });
 
   it('should not re-send the verification email when requested by the user  if no email is sent', (done) => {
-    chai.request(app).post('/api/v1/auth/verify').send({ username: user.username }).end((err, res) => {
+    chai.request(app).post('/api/v1/auth/verify').send({ }).end((err, res) => {
       res.status.should.eql(400);
       res.body.should.be.an('object').with.property('errors');
       done();
@@ -89,7 +87,6 @@ describe('User signup', () => {
   it('should return 400 when a user does not provide a firstName', (done) => {
     chai.request(app).post('/api/v1/auth/signup').send({
       lastName: 'Yomi',
-      username: 'oyomi',
       email: 'johndoe@gmail.com',
       password: '8pcutTway',
       confirmPassword: '8pcutTway',
@@ -107,7 +104,6 @@ describe('User signup', () => {
   it('should return 400 when a user does not provide a lastName', (done) => {
     chai.request(app).post('/api/v1/auth/signup').send({
       firstName: 'Doe',
-      username: 'Johnny',
       email: 'johndoe@gmail.com',
       password: 'Opcut2way',
       confirmPassword: 'Opcut2way',
@@ -126,7 +122,6 @@ describe('User signup', () => {
     chai.request(app).post('/api/v1/auth/signup').send({
       firstName: 'John',
       lastName: 'Doe',
-      username: 'Johnny',
       password: 'Opcut2way',
       confirmPassword: 'Opcut2way',
     }).end((req, res) => {
@@ -140,30 +135,11 @@ describe('User signup', () => {
     });
   });
 
-  it('should return 400 when a user does not provide a username', (done) => {
-    chai.request(app).post('/api/v1/auth/signup').send({
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'johndoe@gmail.com',
-      password: 'Opcut2way',
-      confirmPassword: 'Opcut2way',
-    }).end((req, res) => {
-      res.status.should.eql(400);
-      res.body.should.be.a('object');
-      res.body.should.have.property('status').eql('error');
-      res.body.should.have.property('errors');
-      res.body.errors.should.be.a('object');
-      res.body.errors.should.have.property('username').include('The username field is required.');
-      done();
-    });
-  });
-
   it('should return 400 when a user does not provide a password', (done) => {
     chai.request(app).post('/api/v1/auth/signup').send({
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      username: 'Johnny',
       confirmPassword: 'Opcut2way',
     }).end((req, res) => {
       res.status.should.eql(400);
@@ -181,7 +157,6 @@ describe('User signup', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      username: 'Johnny',
       password: 'Opcut',
     }).end((req, res) => {
       res.status.should.eql(400);
@@ -199,7 +174,6 @@ describe('User signup', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      username: 'Johnny',
       password: 'Opcutuyh',
       confirmPassword: 'Opcutuyh',
     }).end((req, res) => {
@@ -218,7 +192,6 @@ describe('User signup', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      username: 'Johhny',
       password: 'Opcut2way',
     }).end((req, res) => {
       res.status.should.eql(400);
@@ -236,7 +209,6 @@ describe('User signup', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      username: 'Johhny',
       password: 'Opcut2way',
       confirmPassword: 'Opcut2wau',
     }).end((req, res) => {
@@ -257,29 +229,6 @@ describe('User signup', () => {
       res.body.should.have.property('status').eql('error');
       res.body.should.have.property('errors');
       res.body.errors.should.be.a('object');
-      res.body.errors.should.have.property('email').include('User with email: testuser@test.com already exists.');
-      done();
-    });
-  });
-
-  it('should return 409 when a user with the username already exists', (done) => {
-    chai.request(app).post('/api/v1/auth/signup').send(user).end((req, res) => {
-      res.status.should.eql(409);
-      res.body.should.be.a('object');
-      res.body.should.have.property('status').eql('error');
-      res.body.should.have.property('errors');
-      res.body.errors.should.be.a('object');
-      res.body.errors.should.have.property('username').include('User with username: johnny already exists.');
-      done();
-    });
-  });
-
-  it('should return 409 when a user with the username and email already exists', (done) => {
-    chai.request(app).post('/api/v1/auth/signup').send(user).end((req, res) => {
-      res.status.should.eql(409);
-      res.body.should.be.a('object');
-      res.body.should.have.property('status').eql('error');
-      res.body.errors.should.have.property('username').include('User with username: johnny already exists.');
       res.body.errors.should.have.property('email').include('User with email: testuser@test.com already exists.');
       done();
     });

--- a/server/v1/tests/userSignup.test.js
+++ b/server/v1/tests/userSignup.test.js
@@ -4,6 +4,7 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../..';
 import JwtHelper from '../helpers/JwtHelper';
+import AuthController, {} from '../controllers/AuthController';
 
 chai.should();
 chai.use(chaiHttp);
@@ -232,5 +233,11 @@ describe('User signup', () => {
       res.body.errors.should.have.property('email').include('User with email: testuser@test.com already exists.');
       done();
     });
+  });
+
+  it('should automatically create a username for the user from their first name', () => {
+    const username = AuthController.createUsername(user.firstName);
+    username.should.be.a('string');
+    username.should.include('-');
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Removes the username property from required data for user signup, automatically create a username for the user from their first name, and make the username property updateable

#### Description of Task to be completed?
- remove username property from required data for user signup
- automatically create a username for the user from their first name
- make the username property updateable

#### How should this be manually tested?
1. Clone the repository
2. Use the `.env.example` to fill in the `.env` file
3. Startup the command line
4. Run `npm install`
5. Run `npm start`
6. Make a POST request to `/api/v1/auth/signup` and create an account with the properties `firstName`, `lastName`, `email`, `password`, and `confirmPassword`. The username property will be automatically generated from your first name and added to your user details on creation.
7. Make a PUT request to `/api/v1/users/:username` and update your profile with the properties `firstName`, `lastName`, `email`, `username`, `password`, and `confirmPassword`. Note that your email address will cannot be changed.

#### Any background context you want to provide?
- The username field was removed from the signup process so we can reduce the amount of information the user had to supply.

#### What are the relevant pivotal tracker stories?
- [#160690389](https://www.pivotaltracker.com/story/show/160690389)

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A

[Delivers #160690389]